### PR TITLE
WPF-61054-Fixed the Binding Errors in CheckListBox when items are checked using property

### DIFF
--- a/Samples/CheckItem-By-Property/MainWindow.xaml
+++ b/Samples/CheckItem-By-Property/MainWindow.xaml
@@ -25,11 +25,11 @@
                                  Margin="20">
             
                         <!--Binding the IsChecked property from ViewModel-->
-                        <syncfusion:CheckListBox.ItemContainerStyle>
+                        <syncfusion:CheckListBox.Resources>
                             <Style TargetType="syncfusion:CheckListBoxItem">
                                 <Setter Property="IsChecked" Value="{Binding Mode=TwoWay, Path=IsChecked}"/>
                             </Style>
-                        </syncfusion:CheckListBox.ItemContainerStyle>
+                        </syncfusion:CheckListBox.Resources>
 
                         <!--Disable the Virtualization to update the checked item-->
                         <syncfusion:CheckListBox.ItemsPanel>


### PR DESCRIPTION
Changed the style attribute from ItemContainerStyle to Resources to apply style only to CheckListBoxItem.